### PR TITLE
fix: disable self-signup for console

### DIFF
--- a/lib/decisive-engine-aws-cdk-stack.ts
+++ b/lib/decisive-engine-aws-cdk-stack.ts
@@ -228,7 +228,7 @@ export class DecisiveEngineAwsCdkStack extends cdk.Stack {
       signInAliases: {
         email: true,
       },
-      selfSignUpEnabled: true,
+      selfSignUpEnabled: false,
       autoVerify: {
         email: true,
       },


### PR DESCRIPTION
### Any background context you want to provide for reviewers?
Disable self-signup for MDAI Console links -- will prevent undesirable users from getting access to app