### PR TITLE
update k8s version, mdai-console/prometheus charts and node modules

### DIFF
--- a/lib/decisive-engine-aws-cdk-stack.ts
+++ b/lib/decisive-engine-aws-cdk-stack.ts
@@ -310,6 +310,9 @@ export class DecisiveEngineAwsCdkStack extends cdk.Stack {
 
       consoleIngress = {
         'enabled': true,
+        'cognito': {
+          'enabled': config.MDAI_COGNITO.ENABLE === 'true' ? true : false,
+        },
         'acmArn': process.env.MDAI_UI_ACM_ARN,
         'userPoolArn': mdaiUserPool.userPoolArn,
         'userPoolClientId': mdaiAppClient.userPoolClientId,

--- a/lib/decisive-engine-aws-cdk-stack.ts
+++ b/lib/decisive-engine-aws-cdk-stack.ts
@@ -6,7 +6,7 @@ import * as cognito from 'aws-cdk-lib/aws-cognito';
 import * as yaml from 'js-yaml';
 import { readFileSync } from 'fs';
 import { Construct } from 'constructs';
-import { KubectlV28Layer } from '@aws-cdk/lambda-layer-kubectl-v28';
+import { KubectlV30Layer as KubectlLayer } from '@aws-cdk/lambda-layer-kubectl-v30';
 import * as path from 'path';
 import 'dotenv/config'
 
@@ -44,7 +44,7 @@ export class DecisiveEngineAwsCdkStack extends cdk.Stack {
       PROMETHEUS: {
         NAMESPACE: 'default',
         REPO: 'https://prometheus-community.github.io/helm-charts',
-        VERSION: process.env.MDAI_PROMETHEUS_VERSION || '25.11.0',
+        VERSION: process.env.MDAI_PROMETHEUS_VERSION || '25.21.0',
         CHART: 'prometheus',
         RELEASE: 'prometheus',
       },
@@ -65,7 +65,7 @@ export class DecisiveEngineAwsCdkStack extends cdk.Stack {
       MDAI_CONSOLE: {
         NAMESPACE: "default",
         REPO: "https://decisiveai.github.io/mdai-helm-charts",
-        VERSION: process.env.MDAI_CONSOLE_VERSION || "0.0.6-cognito",
+        VERSION: process.env.MDAI_CONSOLE_VERSION || "0.1.0",
         CHART: "mdai-console",
         RELEASE: "mdai-console",
         ACM_ARN: process.env.MDAI_UI_ACM_ARN,
@@ -98,8 +98,8 @@ export class DecisiveEngineAwsCdkStack extends cdk.Stack {
 
     const cluster = new eks.Cluster(this, config.CLUSTER.NAME, {
       clusterName: config.CLUSTER.NAME,
-      version: eks.KubernetesVersion.V1_28,
-      kubectlLayer: new KubectlV28Layer(this, 'kubectl'),
+      version: eks.KubernetesVersion.V1_30,
+      kubectlLayer: new KubectlLayer(this, 'kubectl'),
       mastersRole: engineMasterRole,
       defaultCapacity: config.CLUSTER.CAPACITY,
       defaultCapacityInstance: ec2.InstanceType.of(

--- a/lib/decisive-engine-aws-cdk-stack.ts
+++ b/lib/decisive-engine-aws-cdk-stack.ts
@@ -65,7 +65,7 @@ export class DecisiveEngineAwsCdkStack extends cdk.Stack {
       MDAI_CONSOLE: {
         NAMESPACE: "default",
         REPO: "https://decisiveai.github.io/mdai-helm-charts",
-        VERSION: process.env.MDAI_CONSOLE_VERSION || "0.1.0",
+        VERSION: process.env.MDAI_CONSOLE_VERSION || "0.1.1",
         CHART: "mdai-console",
         RELEASE: "mdai-console",
         ACM_ARN: process.env.MDAI_UI_ACM_ARN,
@@ -309,6 +309,8 @@ export class DecisiveEngineAwsCdkStack extends cdk.Stack {
       mdaiAppClient.node.addDependency(mdaiUserPoolDomain);
 
       consoleIngress = {
+        'enabled': true,
+        'acmArn': process.env.MDAI_UI_ACM_ARN,
         'userPoolArn': mdaiUserPool.userPoolArn,
         'userPoolClientId': mdaiAppClient.userPoolClientId,
         'userPoolDomain': config.MDAI_COGNITO.USER_POOL_DOMAIN,
@@ -325,9 +327,6 @@ export class DecisiveEngineAwsCdkStack extends cdk.Stack {
       wait: true,
       values: {
         'ingress': consoleIngress,
-        'env': {
-          'MDAI_UI_ACM_ARN': process.env.MDAI_UI_ACM_ARN,
-        }
       }
     };
 

--- a/package.json
+++ b/package.json
@@ -11,21 +11,21 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@swc/core": "^1.5.27",
+    "@swc/core": "^1.6.5",
     "@swc/helpers": "^0.5.6",
     "@types/jest": "^29.5.4",
     "@types/js-yaml": "^4.0.6",
-    "@types/node": "20.14.2",
-    "aws-cdk": "^2.145.0",
+    "@types/node": "20.14.9",
+    "aws-cdk": "^2.147.1",
     "jest": "^29.6.4",
     "regenerator-runtime": "^0.14.1",
-    "ts-jest": "^29.1.4",
+    "ts-jest": "^29.1.5",
     "ts-node": "^10.9.1",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.2"
   },
   "dependencies": {
     "@aws-cdk/lambda-layer-kubectl-v30": "^2.0.0",
-    "aws-cdk-lib": "^2.145.0",
+    "aws-cdk-lib": "^2.147.1",
     "constructs": "^10.0.0",
     "dotenv": "^16.4.5",
     "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -11,21 +11,21 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@swc/core": "^1.4.0",
+    "@swc/core": "^1.5.27",
     "@swc/helpers": "^0.5.6",
     "@types/jest": "^29.5.4",
     "@types/js-yaml": "^4.0.6",
-    "@types/node": "20.5.9",
-    "aws-cdk": "^2.126.0",
+    "@types/node": "20.14.2",
+    "aws-cdk": "^2.145.0",
     "jest": "^29.6.4",
     "regenerator-runtime": "^0.14.1",
-    "ts-jest": "^29.1.1",
+    "ts-jest": "^29.1.4",
     "ts-node": "^10.9.1",
-    "typescript": "~5.3.3"
+    "typescript": "~5.4.5"
   },
   "dependencies": {
-    "@aws-cdk/lambda-layer-kubectl-v28": "^2.2.0",
-    "aws-cdk-lib": "^2.126.0",
+    "@aws-cdk/lambda-layer-kubectl-v30": "^2.0.0",
+    "aws-cdk-lib": "^2.145.0",
     "constructs": "^10.0.0",
     "dotenv": "^16.4.5",
     "js-yaml": "^4.1.0",

--- a/test/decisive-engine-aws-cdk.test.ts
+++ b/test/decisive-engine-aws-cdk.test.ts
@@ -64,7 +64,7 @@ describe('DecisiveEngine', () => {
                     Namespace: 'default',
                     CreateNamespace: true,
                     Release: 'prometheus',
-                    Version: '25.11.0',
+                    Version: '25.21.0',
                     Wait: true,
                     Values: '{"prometheus":{"enabled":true},"alertmanager":{"enabled":false},"configmapReload":{"prometheus":{"enabled":false}},"kube-state-metrics":{"enabled":true},"prometheus-node-exporter":{"enabled":false},"prometheus-pushgateway":{"enabled":false},"server":{"retention":"3d","extraFlags":["enable-feature=exemplar-storage","enable-feature=otlp-write-receiver","enable-feature=promql-experimental-functions"],"global":{"scrape_interval":"10s","scrape_timeout":"5s","evaluation_interval":"30s"},"persistentVolume":{"enabled":false,"storageClass":"-","volumeName":"prometheus-pv","size":"5Gi"},"service":{"servicePort":9090},"resources":{"limits":{"memory":"300Mi"}}},"serverFiles":{"prometheus.yml":{"scrape_configs":[{"job_name":"otel-collector","honor_labels":true,"tls_config":{"insecure_skip_verify":true},"kubernetes_sd_configs":[{"role":"pod"}],"relabel_configs":[{"source_labels":["__meta_kubernetes_pod_label_app_kubernetes_io_component","__meta_kubernetes_pod_annotation_prometheus_io_scrape"],"separator":";","regex":"opentelemetry-collector;true","action":"keep"},{"source_labels":["__address__"],"regex":".*:(431[78]|14250)","action":"drop"}]}]}}}',
                 })
@@ -89,7 +89,7 @@ describe('DecisiveEngine', () => {
                     Namespace: 'default',
                     CreateNamespace: true,
                     Release: 'mdai-console',
-                    Version: '0.0.6-cognito',
+                    Version: '0.1.1',
                     Wait: true,
                 })
             )
@@ -106,12 +106,23 @@ describe('DecisiveEngine', () => {
                 })
             )
         })
+        it('should have a Metrics Server Helm chart', () => {
+            template.hasResourceProperties('Custom::AWSCDK-EKS-HelmChart',
+                Match.objectLike({
+                    Repository: 'https://kubernetes-sigs.github.io/metrics-server/',
+                    Namespace: 'kube-system',
+                    Release: 'metrics-server',
+                    Version: '3.12.1',
+                    Wait: true,
+                })
+            )
+        })
     })
     describe('Kubernetes resources', () => {
         it('should have resources', () => {
             template.resourceCountIs('AWS::EKS::Nodegroup', 1)
             template.resourceCountIs('AWS::EC2::VPC', 1)
-            template.resourceCountIs('Custom::AWSCDK-EKS-HelmChart', 7)
+            template.resourceCountIs('Custom::AWSCDK-EKS-HelmChart', 8)
             template.resourceCountIs('AWS::EC2::Subnet', 4)
             template.resourceCountIs('AWS::EC2::NatGateway', 2)
             template.resourceCountIs('AWS::EC2::InternetGateway', 1)


### PR DESCRIPTION
### Any background context you want to provide for reviewers?
* update to k8s 1.30 to keep ahead of AWS EOL
* utilize newest `mdai-console` chart
  * adhere to new values scheme for `mdai-console` chart
* utilize new(est|er) `prometheus` chart
* update various node dependencies to newest versions
### What is the focus or goal of the code changes?
* keep ahead of AWS k8s EOL
* utilize newest `mdai-console`

### Where should the reviewer start?


### Does this add new dependencies? Is there an installation or build procedure? 
`npm i`

### How should this be manually tested?


### Screenshots (if applicable)


### Optional: What gif best describes this PR or how it makes you feel?
