### PR TITLE
chore: bump console version to 0.2.3, remove api

### DIFF
--- a/lib/decisive-engine-aws-cdk-stack.ts
+++ b/lib/decisive-engine-aws-cdk-stack.ts
@@ -135,11 +135,6 @@ export class DecisiveEngineAwsCdkStack extends cdk.Stack {
     });
     metricsServer.node.addDependency(prometheus);
 
-    const mdaiApi = cluster.addHelmChart('mdai-api', {
-      ...config.util.toObject(config.get('mdai-api')),
-    });
-    mdaiApi.node.addDependency(prometheus);
-
     let mdaiAppClient = {} as cdk.aws_cognito.UserPoolClient,
       consoleIngress = {
         'enabled': true,
@@ -177,7 +172,6 @@ export class DecisiveEngineAwsCdkStack extends cdk.Stack {
         accountRecovery: cognito.AccountRecovery.EMAIL_ONLY,
         removalPolicy: cdk.RemovalPolicy.DESTROY,
       });
-      mdaiUserPool.node.addDependency(mdaiApi);
 
       const mdaiUserPoolDomain = mdaiUserPool.addDomain('CognitoDomain', {
         cognitoDomain: {
@@ -218,7 +212,7 @@ export class DecisiveEngineAwsCdkStack extends cdk.Stack {
     const mdaiConsole = cluster.addHelmChart("mdai-console", consoleConfig);
     if (config.get('mdai-cognito.enable') && mdaiAppClient) {
       mdaiConsole.node.addDependency(mdaiAppClient);
-    } 
+    }
 
     //
     //    Karpenter
@@ -241,14 +235,12 @@ export class DecisiveEngineAwsCdkStack extends cdk.Stack {
           }
       );
 
-
       new iam.InstanceProfile(
           this,
           `KarpenterNodeInstanceProfile-${config.get('cluster.name')}-${process.env.AWS_REGION}`, {
             instanceProfileName: `KarpenterNodeInstanceProfile-${config.get('cluster.name')}-${process.env.AWS_REGION}`,
             role: karpenterNodeRole,
           });
-
 
       const conditions = new cdk.CfnJson(this, 'ConditionAudienceServiceAccount', {
         value: {
@@ -404,9 +396,9 @@ export class DecisiveEngineAwsCdkStack extends cdk.Stack {
         includeResourceTypes: ['AWS::EC2::Subnet'],
       });
     }
-    
+
     // Add Datalyzer service to helm chart for installation
-    
+
     cluster.addHelmChart("datalyzer", {
       ...config.util.toObject(config.get('datalyzer'))
     });


### PR DESCRIPTION
### Any background context you want to provide for reviewers?
console is no longer reliant on mdai-api

### What is the focus or goal of the code changes?
bump console helm chart to 0.2.3
remove mdai-api installation

### Where should the reviewer start?


### Does this add new dependencies? Is there an installation or build procedure? 


### How should this be manually tested?
no errors in `mdai-console` 

### Screenshots (if applicable)


### Optional: What gif best describes this PR or how it makes you feel?
